### PR TITLE
Resolve projects relative to the ProjectTree

### DIFF
--- a/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/Util.kt
+++ b/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/Util.kt
@@ -58,6 +58,11 @@ internal fun String.removeStarting(char: Char): String {
     return substring(index)
 }
 
+internal fun String.removeStarting(string: String): String {
+    val index = indexOf(string).takeIf { it >= 0 } ?: return this
+    return substring(index + string.length)
+}
+
 /**
  * Delegates set operation. Meant to be used with Kotlin DSL.
  *

--- a/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/Util.kt
+++ b/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/Util.kt
@@ -58,11 +58,6 @@ internal fun String.removeStarting(char: Char): String {
     return substring(index)
 }
 
-internal fun String.removeStarting(string: String): String {
-    val index = indexOf(string).takeIf { it >= 0 } ?: return this
-    return substring(index + string.length)
-}
-
 /**
  * Delegates set operation. Meant to be used with Kotlin DSL.
  *

--- a/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/storage/ProjectTree.kt
+++ b/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/storage/ProjectTree.kt
@@ -57,5 +57,5 @@ data class ProjectTree(
      *
      * @param project Project reference
      */
-    operator fun get(project: Project) = get(project.path.removeStarting(':'))
+    operator fun get(project: Project) = get(project.path.removeStarting(getPath()).removeStarting(":"))
 }

--- a/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/storage/ProjectTree.kt
+++ b/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/storage/ProjectTree.kt
@@ -57,5 +57,5 @@ data class ProjectTree(
      *
      * @param project Project reference
      */
-    operator fun get(project: Project) = get(project.path.removeStarting(getPath()).removeStarting(":"))
+    operator fun get(project: Project) = get(project.path.removePrefix(getPath()).removeStarting(':'))
 }


### PR DESCRIPTION
This PR fixes the project resolving issue using subproject as a root of the stonecutter tree:
```
An exception occurred applying plugin request [id: 'dev.kikugie.stonecutter']
> Failed to apply plugin 'dev.kikugie.stonecutter'.
   > Could not create an instance of type dev.kikugie.stonecutter.controller.StonecutterController.
      > Failed to apply plugin class 'dev.kikugie.stonecutter.StonecutterPlugin'.
         > Could not create an instance of type dev.kikugie.stonecutter.build.StonecutterBuild.
            > Branch 'project ':mod'' not found in ['']
```
```kotlin
stonecutter {
    kotlinController = true
    centralScript = "build.gradle.kts"

    create("mod") {
        versions("1.21.1")
    }
}
```
