### PR TITLE
Fix to branch caches all being saved to the root cache and not their own, causing the root branch cache to be overwritten.

### DIFF
--- a/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/StonecutterController.kt
+++ b/stonecutter/src/main/kotlin/dev/kikugie/stonecutter/controller/StonecutterController.kt
@@ -138,7 +138,7 @@ public open class StonecutterController(root: Project) :
             nodes.map {
                 NodeInfo(it.metadata, location cut it.location, it.metadata.isActive)
             }
-        ).save(tree.location.resolve("build/stonecutter-cache")).onFailure {
+        ).save(location.resolve("build/stonecutter-cache")).onFailure {
             root.logger.warn("Failed to save branch model for '$id'", it)
         }
     }


### PR DESCRIPTION
I don't know if this was intentional or not. However, it caused the IntelliJ plugin to not find all the available versions.